### PR TITLE
Use SIMD for PC and copying memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 *.asm
 *.out
 ./1bitvm
+
+# Ignore valgrind output
+*grind.out
+*grind.out.*
+
+# No comment
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This software only depens on the GNU C Library, GCC and GNU Make
     ./1bitvm infile
 ### Options
 All described options are settable in `config.h`
+ - `USE_SIMD` - Improves performance by up to 2x on supported platforms (modern x86 CPUs)
  - `DEBUG` - Debugging is availiable through four debug levels
  - `LIMIT` - Maximum number of executed instructions, -1 to disable
  - `EXIT_ON_EOF` - If set, the vm exits imediately after EOF is input, if not set, the vm is allowed to continue - IN will always be 1

--- a/src/config.h
+++ b/src/config.h
@@ -1,3 +1,6 @@
+// comment out to disable SIMD (90% sure its AVX)
+#define USE_SIMD
+
 // debug levels 0-4
 #define DEBUG 0 
 


### PR DESCRIPTION
Added SIMD(AVX) implementations for `get_PC`, `set_PC`, `copy2reg` and `copy16bits`.

It now runs the rule 110 example ~2x faster:
```
# Without SIMD
❯ ./1bitvm example3.out | pv -a > /dev/null
[ 756KiB/s]

# With SIMD
❯ ./1bitvm example3.out | pv -a > /dev/null
[1.46MiB/s]
```

The only trade-off is that the `copy` functions are now unsafe-ish (can probably be solved with a bounds check)